### PR TITLE
Add MRT commands for legacy hardware users

### DIFF
--- a/TSOClient/tso.client/Program.cs
+++ b/TSOClient/tso.client/Program.cs
@@ -48,6 +48,7 @@ namespace FSO.Client
                 gameLocator = new WindowsLocator();
 
             bool useDX = false;
+            bool useMRT = true;
 
             #region User resolution parmeters
 
@@ -87,6 +88,12 @@ namespace FSO.Client
                             case "ogl":
                                 useDX = false;
                                 break;
+                            case "mrt":
+                                useMRT = true;
+                                break;
+                            case "nomrt":
+                                useMRT = false;
+                                break;
                         }
                     }
                 }
@@ -119,6 +126,7 @@ namespace FSO.Client
                 FSOEnvironment.GFXContentDir = "Content/" + (UseDX ? "DX/" : "OGL/");
                 FSOEnvironment.Linux = linux;
                 FSOEnvironment.DirectX = UseDX;
+                FSOEnvironment.UseMRT = useMRT;
                 if (GlobalSettings.Default.LanguageCode == 0) GlobalSettings.Default.LanguageCode = 1;
                 Files.Formats.IFF.Chunks.STR.DefaultLangCode = (Files.Formats.IFF.Chunks.STRLangCode)GlobalSettings.Default.LanguageCode;
 


### PR DESCRIPTION
This is intended as a workaround for users with the multiple render targets issue discussed here: http://forum.freeso.org/threads/call-for-testing-client-with-dx9-support-for-intel-gma.1079/page-2#post-23602

This requires testing prior to being merged as I currently do not have an environment setup to compile the changes.