### PR TITLE
Lot servers handle city disconnects with more grace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ obj/
 [Rr]elease*/
 TSOClient/TSOClient/Content/obj/x86/Debug/ContentPipeline.xml
 pdclient/
+TSOClient/FSO.Benchmark/*
 
 # User-specific files
 *.suo

--- a/TSOClient/FSO.Server/Servers/City/Domain/LotServerPicker.cs
+++ b/TSOClient/FSO.Server/Servers/City/Domain/LotServerPicker.cs
@@ -90,7 +90,14 @@ namespace FSO.Server.Servers.City.Domain
                         Session = session
                     };
                     Servers.Add(state);
-                    ServersByCallsign.Add(session.CallSign, state);
+                    if (ServersByCallsign.ContainsKey(session.CallSign))
+                    {
+                        ServersByCallsign[session.CallSign] = state;
+                    }
+                    else
+                    {
+                        ServersByCallsign.Add(session.CallSign, state);
+                    }
                 }
                 state.Session = session; //can be hot-swapped if we re-establish connection. TODO: verify and look for race conditions
                 state.MaxLots = request.MaxLots;

--- a/TSOClient/FSO.Server/Servers/Lot/Domain/LotContainer.cs
+++ b/TSOClient/FSO.Server/Servers/Lot/Domain/LotContainer.cs
@@ -271,7 +271,10 @@ namespace FSO.Server.Servers.Lot.Domain
 
                 LotPersist.ring_backup_num = newBackup;
                 using (var db = DAFactory.Get())
+                {
                     db.Lots.UpdateRingBackup(LotPersist.lot_id, newBackup);
+                    db.Flush();
+                }
                 return true;
             } catch (Exception e)
             {

--- a/TSOClient/FSO.Server/Servers/Lot/LotServer.cs
+++ b/TSOClient/FSO.Server/Servers/Lot/LotServer.cs
@@ -67,7 +67,14 @@ namespace FSO.Server.Servers.Lot
             }
 
             Connections = Kernel.Get<CityConnections>();
+            Connections.OnCityDisconnected += Connections_OnCityDisconnected;
             Connections.Start();
+        }
+
+        private void Connections_OnCityDisconnected(CityConnection connection)
+        {
+            LOG.Warn("City connection panic, shutting down lots gracefully");
+            Lots.ShutdownByShard(connection.CityConfig.ID);
         }
 
         protected override void HandleVoltronSessionResponse(IAriesSession session, object message)


### PR DESCRIPTION
* Lot servers detect city disconnects and save / shutdown lots
* CityServers now reconnects after a city goes down. This means you can reboot a city without having to reboot the lot servers.
* LotAllocations can now handle a city reconnecting
* Lot servers now release lot locks on shutdown as well as city for cases where the city is offline
* Main thread is no longer shutdown after 4 background loops without tasks. When shutting down no background tasks are generated. If save takes a while this interrupts the save process.
* Bunch of error catches