### PR TITLE
Rack Owners can now name their racks & Other UI polishing tweaks

### DIFF
--- a/TSOClient/tso.client/UI/Controls/UIAlert.cs
+++ b/TSOClient/tso.client/UI/Controls/UIAlert.cs
@@ -103,6 +103,7 @@ namespace FSO.Client.UI.Controls
             if (options.TextEntry)
             {
                 TextBox = new UITextBox();
+                TextBox.MaxChars = options.MaxChars;
                 this.Add(TextBox);
             }
 
@@ -262,7 +263,7 @@ namespace FSO.Client.UI.Controls
         public int Width = 340;
         public int Height = -1;
         public TextAlignment Alignment = TextAlignment.Center;
-
+        public int MaxChars = int.MaxValue;
         public int TextSize = 10;
         public bool ProgressBar;
 

--- a/TSOClient/tso.client/UI/Controls/UITextBox.cs
+++ b/TSOClient/tso.client/UI/Controls/UITextBox.cs
@@ -268,9 +268,13 @@ namespace FSO.Client.UI.Controls
                     m_cursorBlink = !m_cursorBlink;
                 }
 
-                var inputResult = state.InputManager.ApplyKeyboardInput(m_SBuilder, state, SelectionStart, SelectionEnd, true);
+                var allowInput = m_SBuilder.Length < MaxChars;
+
+                var inputResult = state.InputManager.ApplyKeyboardInput(m_SBuilder, state, SelectionStart, SelectionEnd, allowInput);
                 if (inputResult != null)
                 {
+                    Control_ValidateText();
+
                     if (inputResult.ContentChanged)
                     {
                         m_cursorBlink = true;
@@ -558,6 +562,14 @@ namespace FSO.Client.UI.Controls
 
         #region ITextControl Members
 
+        private int m_MaxChars = int.MaxValue;
+
+        public int MaxChars
+        {
+            get { return m_MaxChars; }
+            set { m_MaxChars = value; }
+        }
+
         bool ITextControl.DrawCursor
         {
             get
@@ -565,7 +577,16 @@ namespace FSO.Client.UI.Controls
                 return IsFocused && m_cursorBlink;
             }
         }
-
+        /*
+         * As seen in FSO.Client.UI.Controls.UITextEdit.cs
+         */
+        private void Control_ValidateText()
+        {
+            if (m_SBuilder.Length > MaxChars)
+            {
+                m_SBuilder.Remove(MaxChars, m_SBuilder.Length - MaxChars);
+            }
+        }
         #endregion
     }
 

--- a/TSOClient/tso.client/UI/Panels/EODs/UIAbstractRackEOD.cs
+++ b/TSOClient/tso.client/UI/Panels/EODs/UIAbstractRackEOD.cs
@@ -61,11 +61,15 @@ namespace FSO.Client.UI.Panels.EODs
             OutfitBrowser.OnChange += x => UpdateUIState();
             Add(OutfitBrowser);
 
+            RackName.CurrentText = "Loading rack name...";
+            RackName.Mode = UITextEditMode.ReadOnly;
+
             OutfitPrices = new UITextEdit[] { Outfit1Price, Outfit2Price, Outfit3Price, Outfit4Price, Outfit5Price, Outfit6Price, Outfit7Price, Outfit8Price };
         }
 
         protected virtual void InitEOD()
         {
+            PlaintextHandlers["rack_initialize_name"] = RackNameHandler;
             PlaintextHandlers["rack_show"] = ShowEOD;
             BinaryHandlers["set_outfits"] = ShowStock;
         }
@@ -122,6 +126,11 @@ namespace FSO.Client.UI.Panels.EODs
             var options = GetEODOptions();
             UpdateUIState();
             Controller.ShowEODMode(options);
+        }
+
+        protected virtual void RackNameHandler(string evt, string rackName)
+        {
+            RackName.CurrentText = rackName;
         }
 
         public override void OnClose()

--- a/TSOClient/tso.client/UI/Panels/EODs/UIPermissionDoorEOD.cs
+++ b/TSOClient/tso.client/UI/Panels/EODs/UIPermissionDoorEOD.cs
@@ -82,6 +82,8 @@ namespace FSO.Client.UI.Panels.EODs
             FriendsCheckButton.OnButtonClick += (btn) => { TriggerFlag(VMEODPermissionDoorFlags.MoneyExemptFriend); };
             EmployeesCheckButton.OnButtonClick += (btn) => { TriggerFlag(VMEODPermissionDoorFlags.MoneyExemptEmployee); };
 
+            CodeTextEntry.MaxChars = 9;
+            CodeTextEntry.X -= 14;
             CodeTextEntry.OnChange += CodeTextEntry_OnChange;
             CodeTextEntry.Alignment = Framework.TextAlignment.Center;
             CodeDoorDirections.Wrapped = true;
@@ -217,6 +219,7 @@ namespace FSO.Client.UI.Panels.EODs
                         UIScreen.RemoveDialog(alert);
                     }),
                     TextEntry = true,
+                    MaxChars = 9,
                 }, true);
             }
             else

--- a/TSOClient/tso.client/UI/Panels/EODs/UIRackOwnerEOD.cs
+++ b/TSOClient/tso.client/UI/Panels/EODs/UIRackOwnerEOD.cs
@@ -57,9 +57,17 @@ namespace FSO.Client.UI.Panels.EODs
             btnStock.OnButtonClick += BtnStock_OnButtonClick;
             btnDelete.OnButtonClick += BtnDelete_OnButtonClick;
 
+            RackName.OnChange += Name_OnChange;
+
             foreach (var price in OutfitPrices){
                 price.OnChange += Price_OnChange;
             }
+        }
+
+        protected override void RackNameHandler(string evt, string rackName)
+        {
+            base.RackNameHandler(evt, rackName);
+            RackName.Mode = UITextEditMode.Editor;
         }
 
         private void Price_OnChange(UIElement element)
@@ -109,6 +117,14 @@ namespace FSO.Client.UI.Panels.EODs
             }
 
             DirtyTimeout = GameThread.SetTimeout(() => FlushDirtyPrices(), 2000);
+        }
+
+        private void Name_OnChange(UIElement elemnt)
+        {
+            // change the name of the rack by verifying the data then sending a message to the server
+            var validatedRackName = RackName.CurrentText;
+            if ((validatedRackName.Length > 0) && (validatedRackName.Length < 33))
+                Send("rackowner_update_name", validatedRackName);
         }
 
         private void FlushDirtyPrices()

--- a/TSOClient/tso.client/UI/Panels/EODs/UISlotsEOD.cs
+++ b/TSOClient/tso.client/UI/Panels/EODs/UISlotsEOD.cs
@@ -185,7 +185,7 @@ namespace FSO.Client.UI.Panels.EODs
         {
             Controller.ShowEODMode(new EODLiveModeOpt
             {
-                Buttons = 0,
+                Buttons = 1,
                 Height = EODHeight.TallTall,
                 Length = EODLength.Full,
                 Tips = EODTextTips.Short,

--- a/TSOClient/tso.client/UI/Panels/EODs/UISlotsEOD.cs
+++ b/TSOClient/tso.client/UI/Panels/EODs/UISlotsEOD.cs
@@ -526,6 +526,7 @@ namespace FSO.Client.UI.Panels.EODs
                 System.Environment.NewLine + System.Environment.NewLine + "(This machine cannot hold more than: $" + MachineMaximumBalance + ")",
                 Alignment = TextAlignment.Left,
                 TextEntry = true,
+                MaxChars = 5,
                 Buttons = UIAlertButton.Ok((btn) =>
                 {
                     InputHandler("d", alert.ResponseText.Trim());
@@ -547,6 +548,7 @@ namespace FSO.Client.UI.Panels.EODs
                 System.Environment.NewLine + System.Environment.NewLine + "How much would you like to withdraw?",
                 Alignment = TextAlignment.Left,
                 TextEntry = true,
+                MaxChars = 5,
                 Buttons = UIAlertButton.Ok((btn) =>
                 {
                     InputHandler("w", alert.ResponseText.Trim());

--- a/TSOClient/tso.client/UI/Panels/EODs/UITrunkEOD.cs
+++ b/TSOClient/tso.client/UI/Panels/EODs/UITrunkEOD.cs
@@ -42,10 +42,10 @@ namespace FSO.Client.UI.Panels.EODs
         {
             Controller.ShowEODMode(new EODLiveModeOpt
             {
-                Buttons = 0,
+                Buttons = 1,
                 Height = EODHeight.Tall,
                 Length = EODLength.Full,
-                Tips = EODTextTips.Short,
+                Tips = EODTextTips.None,
                 Timer = EODTimer.None,
                 Expandable = false
             });

--- a/TSOClient/tso.simantics/FSO.SimAntics.csproj
+++ b/TSOClient/tso.simantics/FSO.SimAntics.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Model\VMStackObjectVariable.cs" />
     <Compile Include="NetPlay\Drivers\VMClientDriver.cs" />
     <Compile Include="NetPlay\Drivers\VMServerDriver.cs" />
+    <Compile Include="NetPlay\EODs\Handlers\Data\VMEODRackData.cs" />
     <Compile Include="NetPlay\EODs\Handlers\Data\VMEODSignsData.cs" />
     <Compile Include="NetPlay\EODs\Archetypes\VMBasicEOD.cs" />
     <Compile Include="NetPlay\EODs\Handlers\VMEODDresserPlugin.cs" />

--- a/TSOClient/tso.simantics/NetPlay/EODs/Handlers/Data/VMEODRackData.cs
+++ b/TSOClient/tso.simantics/NetPlay/EODs/Handlers/Data/VMEODRackData.cs
@@ -1,0 +1,46 @@
+﻿using FSO.SimAntics.NetPlay.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+
+namespace FSO.SimAntics.NetPlay.EODs.Handlers.Data
+{
+    public class VMEODRackData : VMSerializable
+    {
+        public string RackName = "Name Your Rack";
+
+        public VMEODRackData() { }
+
+        public VMEODRackData(byte[] data)
+        {
+            using (var reader = new BinaryReader(new MemoryStream(data)))
+            {
+                Deserialize(reader);
+            }
+        }
+
+        public byte[] Save()
+        {
+            using (var stream = new MemoryStream())
+            {
+                var writer = new BinaryWriter(stream);
+                SerializeInto(writer);
+                return stream.ToArray();
+            }
+            
+        }
+
+        public void Deserialize(BinaryReader reader)
+        {
+            RackName = reader.ReadString();
+        }
+
+        public void SerializeInto(BinaryWriter writer)
+        {
+            writer.Write(RackName);
+        }
+    }
+}


### PR DESCRIPTION
•Rack owners can name their racks, and the name is saved on the server and loaded by the next user, customer or owner.
•Only 32 characters are allowed for rack names.
•A couple more Parse methods were replaced with TryParse for safety.
•A few additional checks were made to functions to ensure the calling clients belong to the rack owner
•MaxChars was added to Alert Options
•UITextEdit MaxChars functionality was copied into UITextBox
•Doors and Slots EOD now limit the number of characters the users can enter into the alert.