### PR TITLE
[Bugfix] Read extra unknown byte from TTAT chunk data

### DIFF
--- a/TSOClient/tso.files/Formats/IFF/Chunks/TTAT.cs
+++ b/TSOClient/tso.files/Formats/IFF/Chunks/TTAT.cs
@@ -45,6 +45,7 @@ namespace FSO.Files.Formats.IFF.Chunks
                         tatts[j] = iop.ReadInt32();
                     }
                     var unknown = iop.ReadInt32();
+                    var unknown2 = iop.ReadInt32();
                     TypeAttributesByGUID[guid] = tatts;
                 }
             }


### PR DESCRIPTION
- Fixes crash on loading empty neighbourhoods via Simitone (possibly more)