### PR TITLE
Better User Experience for Login Workflow.

### DIFF
--- a/TSOClient/FSO.UI/Controls/UITextEdit.cs
+++ b/TSOClient/FSO.UI/Controls/UITextEdit.cs
@@ -67,6 +67,7 @@ namespace FSO.Client.UI.Controls
         public event ChangeDelegate OnChange;
         public event KeyPressDelegate OnEnterPress;
         public event KeyPressDelegate OnTabPress;
+        public event KeyPressDelegate OnShiftTabPress;
 
         private UITextEditMode m_Mode = UITextEditMode.Editor;
         private bool m_IsReadOnly = false;
@@ -505,6 +506,7 @@ namespace FSO.Client.UI.Controls
 
                     if (inputResult.EnterPressed && OnEnterPress != null) OnEnterPress(this);
                     if (inputResult.TabPressed && OnTabPress != null) OnTabPress(this);
+                    if (inputResult.ShiftDown && inputResult.TabPressed && OnShiftTabPress != null) OnShiftTabPress(this);
                 }
 
                 if (m_IsDraggingSelection)

--- a/TSOClient/tso.client/UI/Panels/UILoginDialog.cs
+++ b/TSOClient/tso.client/UI/Panels/UILoginDialog.cs
@@ -48,6 +48,7 @@ namespace FSO.Client.UI.Panels
             m_TxtPass.OnChange += M_TxtAccName_OnChange;
             //m_TxtPass.OnTabPress += new KeyPressDelegate(m_TxtPass_OnTabPress);
             m_TxtPass.OnEnterPress += new KeyPressDelegate(loginBtn_OnButtonClick);
+            m_TxtPass.OnShiftTabPress += new KeyPressDelegate(m_TxtPass_OnShiftTabPress);
             this.Add(m_TxtPass);
 
             /** Login button **/
@@ -120,6 +121,11 @@ namespace FSO.Client.UI.Panels
             GameFacade.Screens.inputManager.SetFocus(m_TxtPass);
         }
 
+        public void ClearPassword()
+        {
+            m_TxtPass.CurrentText = "";
+        }
+
         /*void m_TxtPass_OnTabPress(UIElement element)
         {
             GameFacade.Screens.inputManager.SetFocus(m_TxtAccName);
@@ -128,6 +134,11 @@ namespace FSO.Client.UI.Panels
         void m_TxtAccName_OnTabPress(UIElement element)
         {
             GameFacade.Screens.inputManager.SetFocus(m_TxtPass);
+        }
+
+        void m_TxtPass_OnShiftTabPress(UIElement element)
+        {
+            GameFacade.Screens.inputManager.SetFocus(m_TxtAccName);
         }
 
         public string Username

--- a/TSOClient/tso.client/UI/Screens/LoginScreen.cs
+++ b/TSOClient/tso.client/UI/Screens/LoginScreen.cs
@@ -36,6 +36,8 @@ namespace FSO.Client.UI.Screens
         public UILoginDialog LoginDialog;
         public UILoginProgress LoginProgress;
 
+        private UIAlert LastAlert;
+
         private LoginRegulator Regulator;
 
         public LoginScreen(LoginRegulator regulator)
@@ -206,12 +208,16 @@ namespace FSO.Client.UI.Screens
             {
                 ErrorMessage errorMsg = (ErrorMessage)error;
 
+                if (errorMsg.Message.StartsWith("INV-110")) {
+                    LoginDialog.ClearPassword();
+                }
+
                 /** Error message intended for the user **/
                 UIAlertOptions Options = new UIAlertOptions();
                 Options.Message = errorMsg.Message;
                 Options.Title = errorMsg.Title;
                 Options.Buttons = errorMsg.Buttons;
-                GlobalShowAlert(Options, true);
+                LastAlert = GlobalShowAlert(Options, true);
             }
         }
 
@@ -220,7 +226,11 @@ namespace FSO.Client.UI.Screens
         /// </summary>
         public void Login()
         {
-            if (LoginDialog.Username.Length == 0 || LoginDialog.Password.Length == 0){
+            if (LoginDialog.Username.Length == 0 || LoginDialog.Password.Length == 0) {
+                if ( LastAlert != null )
+                {
+                    LoginScreen.RemoveDialog(LastAlert);
+                }
                 return;
             }
 


### PR DESCRIPTION
This PR adjusts the workflow for an incorrect password, giving a better User Experience for users that mistype their passwords, further more, it helps users return to re-enter their password and allows adjustments for incorrectly typed usernames with a Shift + Tab functionality. This PR also adjusts the password workflow such that it no longer spams the login services with incorrect credentials when users press enter again after the wrong credentials are provided.

Commonly users mistype their password, especially if the passwords are "secure", sometimes fat-fingers happen. (I'll admit I enter my password wrong quite commonly into FreeSO for some reason).

Further more, the way the dialog system was presenting the error messages was on top of the UILoginScreen, so every time a user pressed enter after a wrong password, it would continue to spam the login servers with the wrong credentials.

If the users password is not wrong, maybe the enter their username incorrectly, most users are accustom to being able to press Shift + Tab to return to the previous textfield, FreeSO supported tab into the next field, so adding ShiftTab was relatively straight forward for the Login Dialog.

Thank you for reviewing this PR.